### PR TITLE
[ENH] arithmetic combination (addition, multiplication, etc) of sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The version is represented by three digits: a.b.c.
 ---
 ## Unreleased
 
+- sequences.compose: add `ArithOp` for symbolic composition of sequences
+
 ---
 
 ## [0.0.5] - 2024-03-31

--- a/sequence/core/core.py
+++ b/sequence/core/core.py
@@ -35,6 +35,22 @@ class Sequence(ABC):
             return self._as_list(start=item.start, stop=item.stop, step=item.step)
         return self._at(index=item)
 
+    def __add__(self, other):
+        from sequence.sequences.compose.arith import Arith
+
+        if not isinstance(other, Arith):
+            return Arith(sequences=[self, other], operation="+")
+        else:
+            return Arith(sequences=[self, *other.sequences], operation="+")
+
+    def __mul__(self, other):
+        from sequence.sequences.compose.arith import Arith
+
+        if not isinstance(other, Arith):
+            return Arith(sequences=[self, other], operation="*")
+        else:
+            return Arith(sequences=[self, *other.sequences], operation="*")
+
     @abstractmethod
     def is_finite(self) -> bool:
         """Check if the sequence is finite."""

--- a/sequence/core/core.py
+++ b/sequence/core/core.py
@@ -36,20 +36,20 @@ class Sequence(ABC):
         return self._at(index=item)
 
     def __add__(self, other):
-        from sequence.sequences.compose.arith import Arith
+        from sequence.sequences.compose.ArithOp import ArithOp
 
-        if not isinstance(other, Arith):
-            return Arith(sequences=[self, other], operation="+")
+        if not isinstance(other, ArithOp):
+            return ArithOp(sequences=[self, other], operation="+")
         else:
-            return Arith(sequences=[self, *other.sequences], operation="+")
+            return ArithOp(sequences=[self, *other.sequences], operation="+")
 
     def __mul__(self, other):
-        from sequence.sequences.compose.arith import Arith
+        from sequence.sequences.compose.ArithOp import ArithOp
 
-        if not isinstance(other, Arith):
-            return Arith(sequences=[self, other], operation="*")
+        if not isinstance(other, ArithOp):
+            return ArithOp(sequences=[self, other], operation="*")
         else:
-            return Arith(sequences=[self, *other.sequences], operation="*")
+            return ArithOp(sequences=[self, *other.sequences], operation="*")
 
     @abstractmethod
     def is_finite(self) -> bool:

--- a/sequence/sequences/compose/arith.py
+++ b/sequence/sequences/compose/arith.py
@@ -1,0 +1,60 @@
+from sequence.core.core import Sequence
+
+import numpy as np
+
+
+class Arith(Sequence):
+    """Sequences combined via arithmetic operation, e.g., addition, multiplication.
+
+    Parameters
+    ----------
+    sequences : List[Sequence]
+        List of sequences to combine.
+    operation : None, str, function, or numpy ufunc, optional, default = None = mean
+        if str, must be one of "mean", "+" (add), "*" (multiply), "max", "min"
+        if func, must be of signature (1D iterable) -> float
+        operation carried out on the sequences
+    """
+
+    def __init__(self, sequences, operation):
+        super().__init__()
+        self.sequences = sequences
+        self.operation = operation
+        self._op = self._resolve_operation(operation)
+
+    def _resolve_operation(self, operation):
+        """Coerce operation to a numpy.ufunc."""
+        alias_dict = {
+            None: np.mean,
+            "mean": np.mean,
+            "+": np.add,
+            "add": np.add,
+            "*": np.multiply,
+            "mult": np.multiply,
+            "multiply": np.multiply,
+            "min": np.min,
+            "max": np.max,
+        }
+
+        if operation in alias_dict.keys():
+            return alias_dict[operation]
+        else:
+            return operation
+
+    def is_finite(self) -> bool:
+        return any(sequence.is_finite() for sequence in self.sequences)
+
+    def _as_generator(self):
+        op = self._op
+        while True:
+            yield op([next(sequence) for sequence in self.sequences])
+
+    def _as_list(self, stop, start=None, step=None):
+        op = self._op
+        lists = [sequence._as_list(stop, start, step) for sequence in self.sequences]
+        return [op(z) for z in zip(*lists)]
+
+    def _at(self, index: int) -> int:
+        op = self._op
+        ats = [sequence._at(index) for sequence in self.sequences]
+        return op(ats)

--- a/sequence/sequences/compose/arith.py
+++ b/sequence/sequences/compose/arith.py
@@ -23,7 +23,7 @@ class Arith(Sequence):
         self._op = self._resolve_operation(operation)
 
     def __add__(self, other):
-        if not isinstance(other, Arith):
+        if not isinstance(other, Arith) or self._op != other._op:
             return Arith(sequences=[*self.sequences, other], operation="+")
         else:
             return Arith(sequences=[*self.sequences, *other.sequences], operation="+")
@@ -31,7 +31,7 @@ class Arith(Sequence):
     def __mul__(self, other):
         from sequence.sequences.compose.arith import Arith
 
-        if not isinstance(other, Arith):
+        if not isinstance(other, Arith) or self._op != other._op:
             return Arith(sequences=[*self.sequences, other], operation="*")
         else:
             return Arith(sequences=[*self.sequences, *other.sequences], operation="*")

--- a/sequence/sequences/compose/arith.py
+++ b/sequence/sequences/compose/arith.py
@@ -22,6 +22,20 @@ class Arith(Sequence):
         self.operation = operation
         self._op = self._resolve_operation(operation)
 
+    def __add__(self, other):
+        if not isinstance(other, Arith):
+            return Arith(sequences=[*self.sequences, other], operation="+")
+        else:
+            return Arith(sequences=[*self.sequences, *other.sequences], operation="+")
+
+    def __mul__(self, other):
+        from sequence.sequences.compose.arith import Arith
+
+        if not isinstance(other, Arith):
+            return Arith(sequences=[*self.sequences, other], operation="*")
+        else:
+            return Arith(sequences=[*self.sequences, *other.sequences], operation="*")
+
     def _resolve_operation(self, operation):
         """Coerce operation to a numpy.ufunc."""
         alias_dict = {

--- a/sequence/sequences/compose/arith.py
+++ b/sequence/sequences/compose/arith.py
@@ -1,53 +1,58 @@
+from math import gcd, lcm, prod
+
 from sequence.core.core import Sequence
 
-import numpy as np
 
-
-class Arith(Sequence):
-    """Sequences combined via arithmetic operation, e.g., addition, multiplication.
+class ArithOp(Sequence):
+    """Sequences combined via ArithOpmetic operation, e.g., addition, multiplication.
 
     Parameters
     ----------
     sequences : List[Sequence]
         List of sequences to combine.
-    operation : None, str, function, or numpy ufunc, optional, default = None = mean
-        if str, must be one of "mean", "+" (add), "*" (multiply), "max", "min"
+    operation : None, str, function, or numpy ufunc, optional, default = "+""
+        if str, must be one of "+" (add), "*" (multiply), "max", "min", "gcd", "lcm"
         if func, must be of signature (1D iterable) -> float
         operation carried out on the sequences
     """
 
-    def __init__(self, sequences, operation):
+    def __init__(self, sequences, operation="+"):
         super().__init__()
         self.sequences = sequences
         self.operation = operation
         self._op = self._resolve_operation(operation)
 
     def __add__(self, other):
-        if not isinstance(other, Arith) or self._op != other._op:
-            return Arith(sequences=[*self.sequences, other], operation="+")
+        if not isinstance(other, ArithOp) or self._op != other._op:
+            return ArithOp(sequences=[*self.sequences, other], operation="+")
         else:
-            return Arith(sequences=[*self.sequences, *other.sequences], operation="+")
+            return ArithOp(sequences=[*self.sequences, *other.sequences], operation="+")
 
     def __mul__(self, other):
-        from sequence.sequences.compose.arith import Arith
+        from sequence.sequences.compose.ArithOp import ArithOp
 
-        if not isinstance(other, Arith) or self._op != other._op:
-            return Arith(sequences=[*self.sequences, other], operation="*")
+        if not isinstance(other, ArithOp) or self._op != other._op:
+            return ArithOp(sequences=[*self.sequences, other], operation="*")
         else:
-            return Arith(sequences=[*self.sequences, *other.sequences], operation="*")
+            return ArithOp(sequences=[*self.sequences, *other.sequences], operation="*")
+
+    def __len__(self):
+        lens = [len(sequence) for sequence in self.sequences]
+        return min(lens)
 
     def _resolve_operation(self, operation):
         """Coerce operation to a numpy.ufunc."""
         alias_dict = {
-            None: np.mean,
-            "mean": np.mean,
-            "+": np.add,
-            "add": np.add,
-            "*": np.multiply,
-            "mult": np.multiply,
-            "multiply": np.multiply,
-            "min": np.min,
-            "max": np.max,
+            None: sum,
+            "+": sum,
+            "add": sum,
+            "*": prod,
+            "mult": prod,
+            "multiply": prod,
+            "min": min,
+            "max": max,
+            "gcd": gcd,
+            "lcm": lcm,
         }
 
         if operation in alias_dict.keys():


### PR DESCRIPTION
Fixes https://github.com/VascoSch92/sequentium/issues/21, implements a class `Arith` which allows to create symbolic arithmetic combinations of sequences. Evaluation methods carry out the eager computation.

Also implements dunders `__add__`, `__mul__` in the base class.

Does not implement `__len__`, or other sub-class specific methods for now - my intuition would be to make some of the subclasses property tags instead (using scikit-base, see https://github.com/VascoSch92/sequentium/issues/45).

I'm also a bit puzzled about the test framework, so I did not add any tests, but I reckon the class has to be added to a config somewhere. Advice appreciated.